### PR TITLE
Make TX dithering configurable for 16-bit and 24-bit output

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ At this point, Inferno will roughly become alternative to Dante Virtual Soundcar
 * ability to work as a clock source (PTPv1 leader) - Statime
   * it is already possible if you use PTPv2 - in theory you should be able to make Inferno-only AoIP network - not tested yet
 * add more apps and Linux distributions to the integration test
-* bit-perfect transmitter (currently 32-bit integers are always used internally and conversion to 24-bit or 16-bit adds dither)
+* bit-perfect transmitter (32-bit integers are always used internally; TX dithering for 16-bit and 24-bit output is configurable via `TX_SOURCE_BIT_DEPTH`)
 * command line helper / TUI / GUI
 * installer script, with cross compilation support
 * more refactoring of network packets serializers & deserializers to make more code reusable in upcoming controller app (because DC is bloated closed source and bad UX)

--- a/inferno_aoip/src/device_server/flows_tx.rs
+++ b/inferno_aoip/src/device_server/flows_tx.rs
@@ -101,12 +101,18 @@ struct FlowsTransmitterInternal<P: ProxyToSamplesBuffer> {
   clock_offset_samples: LongClockDiff,
   max_lag_samples: usize,
   timestamp_shift: ClockDiff,
+  tx_source_bit_depth: u8,
   current_timestamp: Arc<AtomicUsize>,
   on_transfer: Option<TransferNotifier>,
   //callback: SamplesRequestCallback,
 }
 
 impl<P: ProxyToSamplesBuffer> FlowsTransmitterInternal<P> {
+  #[inline(always)]
+  fn should_dither(&self, output_bit_depth: u8) -> bool {
+    self.tx_source_bit_depth > output_bit_depth
+  }
+
   fn now(&self) -> Option<LongClock> {
     self.clock.now_in_timebase(self.sample_rate as u64)
   }
@@ -120,6 +126,8 @@ impl<P: ProxyToSamplesBuffer> FlowsTransmitterInternal<P> {
     let max_lag_samples = self.max_lag_samples;
     let mut iterations = 0;
     let mut max_missing_samples = 0;
+    let dither_16 = self.should_dither(16);
+    let dither_24 = self.should_dither(24);
     for flow in &mut self.flows.iter_mut().filter_map(|opt| opt.as_mut()) {
       if flow.expired.load(Ordering::Relaxed) {
         continue;
@@ -166,8 +174,20 @@ impl<P: ProxyToSamplesBuffer> FlowsTransmitterInternal<P> {
             let start = 9 + index_in_flow * flow.bytes_per_sample;
             let samples = &tmp_samples[0..flow.fpp];
             match flow.bytes_per_sample {
-              2 => write_s16_samples(samples, &mut pbuff, start, stride, Some(dither_rng)),
-              3 => write_s24_samples(samples, &mut pbuff, start, stride, Some(dither_rng)),
+              2 => write_s16_samples::<_, SmallRng>(
+                samples,
+                &mut pbuff,
+                start,
+                stride,
+                if dither_16 { Some(dither_rng) } else { None },
+              ),
+              3 => write_s24_samples::<_, SmallRng>(
+                samples,
+                &mut pbuff,
+                start,
+                stride,
+                if dither_24 { Some(dither_rng) } else { None },
+              ),
               4 => write_s32_samples::<_, SmallRng>(samples, &mut pbuff, start, stride, None),
               other => {
                 error!("BUG: unsupported bytes per sample {}", other);
@@ -446,6 +466,7 @@ fn split_handle(h: FlowHandle) -> (u32, u16) {
 impl FlowsTransmitter {
   async fn run<P: ProxyToSamplesBuffer>(
     rx: mpsc::Receiver<Command>,
+    tx_source_bit_depth: u8,
     clock_recv: RealTimeBoxReceiver<Option<ClockOverlay>>,
     sample_rate: u32,
     latency_ns: usize,
@@ -466,6 +487,7 @@ impl FlowsTransmitter {
       send_latency_samples: latency.try_into().unwrap(), // TODO in ALSA plugin should be 0, the more the worse because aplay wants to fill the whole buffer
       max_lag_samples,
       timestamp_shift: (0 as ClockDiff).wrapping_sub_unsigned(latency.try_into().unwrap()),
+      tx_source_bit_depth,
       clock_offset_samples: (CLOCK_OFFSET_NS as i64 * sample_rate as i64 / 1_000_000_000i64)
         .try_into()
         .unwrap(),
@@ -477,6 +499,7 @@ impl FlowsTransmitter {
   pub fn start<P: ProxyToSamplesBuffer + Send + Sync + 'static>(
     self_info: Arc<DeviceInfo>,
     tx_latency_ns: usize,
+    tx_source_bit_depth: u8,
     clock_recv: RealTimeBoxReceiver<Option<ClockOverlay>>,
     channels_outputs: Vec<RBOutput<Sample, P>>,
     start_time_rx: Option<tokio::sync::oneshot::Receiver<Clock>>,
@@ -490,6 +513,7 @@ impl FlowsTransmitter {
     let thread_join = run_future_in_new_thread("flows TX", move || {
       Self::run(
         rx,
+        tx_source_bit_depth,
         clock_recv,
         srate,
         0, /*LATENCY TODO*/

--- a/inferno_aoip/src/device_server/mod.rs
+++ b/inferno_aoip/src/device_server/mod.rs
@@ -68,6 +68,7 @@ pub struct DeviceServer {
   mdns_server: Arc<DeviceMDNSResponder>,
   mcast_tx: mpsc::Sender<crate::protocol::mcast::MulticastMessage>,
   tx_latency_ns: u32,
+  tx_source_bit_depth: u8,
   channels_sub_tx: watch::Sender<Option<Arc<ChannelsSubscriber>>>,
   flows_tx: Arc<Mutex<Option<FlowsTransmitter>>>,
   tx_multicasts: Arc<Mutex<Option<TransmitMulticasts>>>,
@@ -162,6 +163,7 @@ impl DeviceServer {
       mdns_server,
       mcast_tx,
       tx_latency_ns: settings.tx_latency_ns,
+      tx_source_bit_depth: settings.tx_source_bit_depth,
       channels_sub_tx,
       flows_tx,
       tx_multicasts,
@@ -298,6 +300,7 @@ impl DeviceServer {
     let (flows_tx_handle, flows_tx_thread) = flows_tx::FlowsTransmitter::start(
       self.self_info.clone(),
       self.tx_latency_ns.try_into().unwrap(),
+      self.tx_source_bit_depth,
       self.get_realtime_clock_receiver(),
       rb_outputs.clone(),
       start_time_rx,

--- a/inferno_aoip/src/device_server/settings.rs
+++ b/inferno_aoip/src/device_server/settings.rs
@@ -151,6 +151,7 @@ pub struct Settings {
   pub tx_latency_ns: u32,
   pub clock_path: Option<PathBuf>,
   pub use_safe_clock: bool,
+  pub tx_source_bit_depth: u8,
 }
 
 impl Settings {
@@ -177,6 +178,14 @@ impl Settings {
       .get("USE_SAFE_CLOCK")
       .map(|s| s.parse().expect("invalid USE_SAFE_CLOCK, must be boolean"))
       .unwrap_or(false);
+    let tx_source_bit_depth = config
+      .get("TX_SOURCE_BIT_DEPTH")
+      .map(|s| s.parse::<u8>().expect("invalid TX_SOURCE_BIT_DEPTH, must be one of: 16, 24, 32"))
+      .unwrap_or(32);
+    assert!(
+      matches!(tx_source_bit_depth, 16 | 24 | 32),
+      "invalid TX_SOURCE_BIT_DEPTH, must be one of: 16, 24, 32"
+    );
 
     let mut result = Self {
       self_info,
@@ -186,6 +195,7 @@ impl Settings {
         .unwrap_or(10_000_000),
       clock_path: config.get("CLOCK_PATH").map(|p| p.try_into().unwrap()),
       use_safe_clock,
+      tx_source_bit_depth,
     };
 
     // the following should be harmless, as the application still has the chance to overwrite it


### PR DESCRIPTION
Inferno currently applies dither when packetizing both 16-bit and 24-bit TX audio. That can be a reasonable default when reducing from a higher precision processing domain, but it is too rigid for transparent transport use cases.

In transport-style applications, the source is often already effectively 16-bit or 24-bit PCM represented in Inferno's i32 sample format. Adding hardcoded dither changes the transmitted low bits, which prevents exact payload preservation and makes bit-accurate end-to-end validation impossible.

Inferno cannot reliably infer the caller's intent from i32 samples alone, so this change adds explicit TX_DITHER_16BIT and TX_DITHER_24BIT settings instead of trying to auto-detect when dithering should apply.

Both settings default to true to preserve existing behavior. Callers that need transparent transport can now disable dithering selectively, for example by turning off 24-bit TX dithering while keeping the 16-bit path unchanged.