### PR TITLE
Add owned-buffer TX API and precise read-position snapshots for timestamped external sources

### DIFF
--- a/inferno_aoip/src/device_server/flows_tx.rs
+++ b/inferno_aoip/src/device_server/flows_tx.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr, UdpSocket};
 use std::num::Wrapping;
-use std::sync::atomic::{AtomicBool, AtomicUsize};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
 use std::sync::{Arc, RwLock};
 use std::thread::JoinHandle;
 use std::{collections::BTreeMap, net::SocketAddr, sync::atomic::AtomicU32, time::Duration};
@@ -106,6 +106,10 @@ struct FlowsTransmitterInternal<P: ProxyToSamplesBuffer> {
   /// The actual ring buffer position last read from (start_ts from the most recent TX cycle).
   /// Exposed so external buffer writers can align their write positions.
   read_position: Arc<AtomicUsize>,
+  /// Consistent (read_pos, monotonic_time) snapshot for precise timing calibration.
+  read_position_snapshot: Option<Arc<super::ReadPositionSnapshot>>,
+  /// Reference instant for monotonic_nanos in the snapshot.
+  snapshot_ref_instant: std::time::Instant,
   on_transfer: Option<TransferNotifier>,
   //callback: SamplesRequestCallback,
 }
@@ -156,6 +160,14 @@ impl<P: ProxyToSamplesBuffer> FlowsTransmitterInternal<P> {
         pbuff[5..9].copy_from_slice(&(subsec_samples as u32).to_be_bytes());
         let start_ts = (flow.next_ts as Clock).wrapping_add_signed(self.timestamp_shift);
         self.read_position.store(start_ts, Ordering::Release);
+        if let Some(snapshot) = &self.read_position_snapshot {
+            let seq = snapshot.seq.load(Ordering::Relaxed);
+            snapshot.seq.store(seq.wrapping_add(1), Ordering::Release); // odd = writing
+            snapshot.read_position.store(start_ts, Ordering::Relaxed);
+            let nanos = self.snapshot_ref_instant.elapsed().as_nanos() as u64;
+            snapshot.monotonic_nanos.store(nanos, Ordering::Relaxed);
+            snapshot.seq.store(seq.wrapping_add(2), Ordering::Release); // even = stable
+        }
         for (index_in_flow, &ch_opt) in flow.channel_indices.iter().enumerate() {
           if let Some(ch_index) = ch_opt {
             //(self.callback)(flow.next_ts, ch_index, &mut tmp_samples[0..flow.fpp]);
@@ -479,6 +491,7 @@ impl FlowsTransmitter {
     start_time_rx: Option<tokio::sync::oneshot::Receiver<Clock>>,
     current_timestamp: Arc<AtomicUsize>,
     read_position: Arc<AtomicUsize>,
+    read_position_snapshot: Option<Arc<super::ReadPositionSnapshot>>,
     on_transfer: Option<TransferNotifier>,
   ) {
     let latency: u32 = (latency_ns as u64 * sample_rate as u64 / 1_000_000_000u64).try_into().unwrap();
@@ -498,6 +511,8 @@ impl FlowsTransmitter {
         .unwrap(),
       current_timestamp,
       read_position,
+      read_position_snapshot,
+      snapshot_ref_instant: std::time::Instant::now(),
       on_transfer,
     };
     internal.run(start_time_rx).await;
@@ -511,6 +526,7 @@ impl FlowsTransmitter {
     start_time_rx: Option<tokio::sync::oneshot::Receiver<Clock>>,
     current_timestamp: Arc<AtomicUsize>,
     read_position: Arc<AtomicUsize>,
+    read_position_snapshot: Option<Arc<super::ReadPositionSnapshot>>,
     on_transfer: Option<TransferNotifier>,
   ) -> (Self, JoinHandle<()>) {
     let (tx, rx) = mpsc::channel(100);
@@ -530,6 +546,7 @@ impl FlowsTransmitter {
         start_time_rx,
         current_timestamp,
         read_position,
+        read_position_snapshot,
         on_transfer,
       )
       .boxed_local()

--- a/inferno_aoip/src/device_server/flows_tx.rs
+++ b/inferno_aoip/src/device_server/flows_tx.rs
@@ -1,6 +1,6 @@
 use std::net::{IpAddr, Ipv4Addr, UdpSocket};
 use std::num::Wrapping;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize};
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, RwLock};
 use std::thread::JoinHandle;
 use std::{collections::BTreeMap, net::SocketAddr, sync::atomic::AtomicU32, time::Duration};
@@ -161,12 +161,8 @@ impl<P: ProxyToSamplesBuffer> FlowsTransmitterInternal<P> {
         let start_ts = (flow.next_ts as Clock).wrapping_add_signed(self.timestamp_shift);
         self.read_position.store(start_ts, Ordering::Release);
         if let Some(snapshot) = &self.read_position_snapshot {
-            let seq = snapshot.seq.load(Ordering::Relaxed);
-            snapshot.seq.store(seq.wrapping_add(1), Ordering::Release); // odd = writing
-            snapshot.read_position.store(start_ts, Ordering::Relaxed);
             let nanos = self.snapshot_ref_instant.elapsed().as_nanos() as u64;
-            snapshot.monotonic_nanos.store(nanos, Ordering::Relaxed);
-            snapshot.seq.store(seq.wrapping_add(2), Ordering::Release); // even = stable
+            snapshot.publish(start_ts, nanos);
         }
         for (index_in_flow, &ch_opt) in flow.channel_indices.iter().enumerate() {
           if let Some(ch_index) = ch_opt {
@@ -511,8 +507,14 @@ impl FlowsTransmitter {
         .unwrap(),
       current_timestamp,
       read_position,
-      read_position_snapshot,
-      snapshot_ref_instant: std::time::Instant::now(),
+      read_position_snapshot: read_position_snapshot.clone(),
+      snapshot_ref_instant: {
+        let now = std::time::Instant::now();
+        if let Some(snap) = &read_position_snapshot {
+          snap.init_ref_instant(now);
+        }
+        now
+      },
       on_transfer,
     };
     internal.run(start_time_rx).await;

--- a/inferno_aoip/src/device_server/flows_tx.rs
+++ b/inferno_aoip/src/device_server/flows_tx.rs
@@ -103,6 +103,9 @@ struct FlowsTransmitterInternal<P: ProxyToSamplesBuffer> {
   timestamp_shift: ClockDiff,
   tx_source_bit_depth: u8,
   current_timestamp: Arc<AtomicUsize>,
+  /// The actual ring buffer position last read from (start_ts from the most recent TX cycle).
+  /// Exposed so external buffer writers can align their write positions.
+  read_position: Arc<AtomicUsize>,
   on_transfer: Option<TransferNotifier>,
   //callback: SamplesRequestCallback,
 }
@@ -152,6 +155,7 @@ impl<P: ProxyToSamplesBuffer> FlowsTransmitterInternal<P> {
         pbuff[1..5].copy_from_slice(&(seconds as u32).to_be_bytes());
         pbuff[5..9].copy_from_slice(&(subsec_samples as u32).to_be_bytes());
         let start_ts = (flow.next_ts as Clock).wrapping_add_signed(self.timestamp_shift);
+        self.read_position.store(start_ts, Ordering::Release);
         for (index_in_flow, &ch_opt) in flow.channel_indices.iter().enumerate() {
           if let Some(ch_index) = ch_opt {
             //(self.callback)(flow.next_ts, ch_index, &mut tmp_samples[0..flow.fpp]);
@@ -474,6 +478,7 @@ impl FlowsTransmitter {
     channels_outputs: Vec<RBOutput<Sample, P>>,
     start_time_rx: Option<tokio::sync::oneshot::Receiver<Clock>>,
     current_timestamp: Arc<AtomicUsize>,
+    read_position: Arc<AtomicUsize>,
     on_transfer: Option<TransferNotifier>,
   ) {
     let latency: u32 = (latency_ns as u64 * sample_rate as u64 / 1_000_000_000u64).try_into().unwrap();
@@ -492,6 +497,7 @@ impl FlowsTransmitter {
         .try_into()
         .unwrap(),
       current_timestamp,
+      read_position,
       on_transfer,
     };
     internal.run(start_time_rx).await;
@@ -504,6 +510,7 @@ impl FlowsTransmitter {
     channels_outputs: Vec<RBOutput<Sample, P>>,
     start_time_rx: Option<tokio::sync::oneshot::Receiver<Clock>>,
     current_timestamp: Arc<AtomicUsize>,
+    read_position: Arc<AtomicUsize>,
     on_transfer: Option<TransferNotifier>,
   ) -> (Self, JoinHandle<()>) {
     let (tx, rx) = mpsc::channel(100);
@@ -522,6 +529,7 @@ impl FlowsTransmitter {
         channels_outputs,
         start_time_rx,
         current_timestamp,
+        read_position,
         on_transfer,
       )
       .boxed_local()

--- a/inferno_aoip/src/device_server/mod.rs
+++ b/inferno_aoip/src/device_server/mod.rs
@@ -2,7 +2,7 @@ use crate::mdns_client::{MdnsClient, PointerToMulticast};
 use crate::media_clock::{
   async_clock_receiver_to_realtime, make_shared_media_clock, start_clock_receiver, ClockReceiver,
 };
-use crate::ring_buffer::{self, OwnedBuffer, ProxyToBuffer, ProxyToSamplesBuffer, RBOutput};
+use crate::ring_buffer::{self, ProxyToBuffer, ProxyToSamplesBuffer};
 use crate::state_storage::StateStorage;
 use atomic::Atomic;
 use flows_tx::FlowsTransmitter;
@@ -42,7 +42,8 @@ pub(crate) mod tx_multicasts;
 
 pub use crate::common::{Clock, ClockDiff, Sample};
 pub use crate::media_clock::{MediaClock, RealTimeClockReceiver};
-pub use crate::ring_buffer::{ExternalBufferParameters, PositionReportDestination};
+pub use crate::ring_buffer::{ExternalBufferParameters, OwnedBuffer, PositionReportDestination, RBInput, RBOutput};
+pub use crate::ring_buffer::new_owned as new_owned_ring_buffer;
 pub use settings::Settings;
 pub type AtomicSample = atomic::Atomic<Sample>;
 
@@ -286,13 +287,52 @@ impl DeviceServer {
       tx_channels_buffers.iter().map(|par| ring_buffer::wrap_external_source(par, 0)).collect();
     let rbs = rb_outputs.iter().map(|rbo| rbo.shared().clone()).collect_vec();
     *self.tx_peaks_supplier.write().unwrap() = Box::new(move || peaks_of_buffers(&rbs));
-    self.transmit(Some(start_time_rx), rb_outputs, current_timestamp, on_transfer).await;
+    self.transmit(Some(start_time_rx), rb_outputs, current_timestamp, None, on_transfer).await;
   }
+
+  /// Start transmitting from owned ring buffers.
+  ///
+  /// Creates `channel_count` owned ring buffers and returns the `RBInput` write handles.
+  /// The caller writes audio samples via `RBInput::write_from_at()`.
+  /// The `RBOutput` read handles are passed to the internal transmitter.
+  ///
+  /// Unlike `transmit_from_external_buffer`, owned buffers:
+  /// - Track `readable_pos` on the write side (inferno only reads validated data)
+  /// - Have `unconditional_read() == false` (reads check readable_pos)
+  /// - Support hole detection and fill via `hole_fix_wait`
+  ///
+  /// The `read_position` atomic is updated by the FlowsTransmitter with the actual
+  /// ring buffer position it reads from (`start_ts = next_ts + timestamp_shift`).
+  /// This allows external writers to align their write positions correctly.
+  pub async fn transmit_from_owned_buffer(
+    &mut self,
+    channel_count: usize,
+    buffer_length: usize,
+    hole_fix_wait: usize,
+    start_time_rx: tokio::sync::oneshot::Receiver<Clock>,
+    current_timestamp: Arc<AtomicUsize>,
+    read_position: Arc<AtomicUsize>,
+    on_transfer: Option<TransferNotifier>,
+  ) -> Vec<ring_buffer::RBInput<Sample, OwnedBuffer<Atomic<Sample>>>> {
+    let mut rb_inputs = Vec::with_capacity(channel_count);
+    let mut rb_outputs = Vec::with_capacity(channel_count);
+    for _ in 0..channel_count {
+      let (input, output) = ring_buffer::new_owned(buffer_length, 0, hole_fix_wait);
+      rb_inputs.push(input);
+      rb_outputs.push(output);
+    }
+    let rbs = rb_outputs.iter().map(|rbo| rbo.shared().clone()).collect_vec();
+    *self.tx_peaks_supplier.write().unwrap() = Box::new(move || peaks_of_buffers(&rbs));
+    self.transmit(Some(start_time_rx), rb_outputs, current_timestamp, Some(read_position), on_transfer).await;
+    rb_inputs
+  }
+
   async fn transmit<P: ProxyToSamplesBuffer + Send + Sync + 'static>(
     &mut self,
     start_time_rx: Option<tokio::sync::oneshot::Receiver<Clock>>,
     rb_outputs: Vec<RBOutput<Sample, P>>,
     current_timestamp: Arc<AtomicUsize>,
+    read_position: Option<Arc<AtomicUsize>>,
     on_transfer: Option<TransferNotifier>,
   ) {
     let clock_rx = self.clock_receiver.subscribe();
@@ -305,6 +345,7 @@ impl DeviceServer {
       rb_outputs.clone(),
       start_time_rx,
       current_timestamp.clone(),
+      read_position.unwrap_or_else(|| Arc::new(AtomicUsize::new(usize::MAX))),
       on_transfer,
     );
     *self.flows_tx.lock().await = Some(flows_tx_handle);

--- a/inferno_aoip/src/device_server/mod.rs
+++ b/inferno_aoip/src/device_server/mod.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 use std::io::Write;
 use std::pin::Pin;
 use std::sync::atomic::AtomicUsize;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 
 use std::time::{Duration, Instant};
 use tokio::sync::{broadcast as broadcast_queue, mpsc, watch, Mutex};
@@ -51,10 +51,13 @@ pub type AtomicSample = atomic::Atomic<Sample>;
 /// at the exact point it updates `read_position`. Readers use a seqlock protocol:
 /// odd seq = writer active, even seq = stable. Retry if seq changes between reads.
 pub struct ReadPositionSnapshot {
-    pub seq: AtomicUsize,
-    pub read_position: AtomicUsize,
-    /// Nanoseconds elapsed since a reference Instant stored in the TX thread.
-    pub monotonic_nanos: std::sync::atomic::AtomicU64,
+    seq: AtomicUsize,
+    read_position: AtomicUsize,
+    /// Nanoseconds elapsed since `ref_instant`.
+    monotonic_nanos: std::sync::atomic::AtomicU64,
+    /// Reference instant for monotonic_nanos. Set once by the TX thread at startup.
+    /// Readers reconstruct the snapshot instant as `ref_instant + Duration::from_nanos(monotonic_nanos)`.
+    ref_instant: OnceLock<std::time::Instant>,
 }
 
 impl ReadPositionSnapshot {
@@ -63,7 +66,48 @@ impl ReadPositionSnapshot {
             seq: AtomicUsize::new(0),
             read_position: AtomicUsize::new(usize::MAX),
             monotonic_nanos: std::sync::atomic::AtomicU64::new(0),
+            ref_instant: OnceLock::new(),
         }
+    }
+
+    pub(crate) fn init_ref_instant(&self, instant: std::time::Instant) {
+        let _ = self.ref_instant.set(instant);
+    }
+
+    pub(crate) fn publish(&self, read_position: usize, monotonic_nanos: u64) {
+        let seq = self.seq.load(std::sync::atomic::Ordering::Relaxed);
+        self.seq
+            .store(seq.wrapping_add(1), std::sync::atomic::Ordering::Release);
+        self.read_position
+            .store(read_position, std::sync::atomic::Ordering::Relaxed);
+        self.monotonic_nanos
+            .store(monotonic_nanos, std::sync::atomic::Ordering::Relaxed);
+        self.seq
+            .store(seq.wrapping_add(2), std::sync::atomic::Ordering::Release);
+    }
+
+    pub fn try_read(&self) -> Option<(usize, std::time::Instant)> {
+        let ref_instant = *self.ref_instant.get()?;
+        for _ in 0..8 {
+            let seq1 = self.seq.load(std::sync::atomic::Ordering::Acquire);
+            if seq1 & 1 != 0 {
+                continue;
+            }
+            let pos = self
+                .read_position
+                .load(std::sync::atomic::Ordering::Relaxed);
+            let nanos = self
+                .monotonic_nanos
+                .load(std::sync::atomic::Ordering::Relaxed);
+            let seq2 = self.seq.load(std::sync::atomic::Ordering::Acquire);
+            if seq1 == seq2 {
+                if pos == usize::MAX {
+                    return None;
+                }
+                return Some((pos, ref_instant + Duration::from_nanos(nanos)));
+            }
+        }
+        None
     }
 }
 

--- a/inferno_aoip/src/device_server/mod.rs
+++ b/inferno_aoip/src/device_server/mod.rs
@@ -47,6 +47,26 @@ pub use crate::ring_buffer::new_owned as new_owned_ring_buffer;
 pub use settings::Settings;
 pub type AtomicSample = atomic::Atomic<Sample>;
 
+/// Consistent (read_position, monotonic_time) snapshot written by the TX thread
+/// at the exact point it updates `read_position`. Readers use a seqlock protocol:
+/// odd seq = writer active, even seq = stable. Retry if seq changes between reads.
+pub struct ReadPositionSnapshot {
+    pub seq: AtomicUsize,
+    pub read_position: AtomicUsize,
+    /// Nanoseconds elapsed since a reference Instant stored in the TX thread.
+    pub monotonic_nanos: std::sync::atomic::AtomicU64,
+}
+
+impl ReadPositionSnapshot {
+    pub fn new() -> Self {
+        Self {
+            seq: AtomicUsize::new(0),
+            read_position: AtomicUsize::new(usize::MAX),
+            monotonic_nanos: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+}
+
 use channels_subscriber::{ChannelsBuffering, ChannelsSubscriber, ExternalBuffering, OwnedBuffering};
 use peaks::peaks_of_buffers;
 use samples_collector::{RealTimeSamplesReceiver, SamplesCallback, SamplesCollector};
@@ -287,7 +307,7 @@ impl DeviceServer {
       tx_channels_buffers.iter().map(|par| ring_buffer::wrap_external_source(par, 0)).collect();
     let rbs = rb_outputs.iter().map(|rbo| rbo.shared().clone()).collect_vec();
     *self.tx_peaks_supplier.write().unwrap() = Box::new(move || peaks_of_buffers(&rbs));
-    self.transmit(Some(start_time_rx), rb_outputs, current_timestamp, None, on_transfer).await;
+    self.transmit(Some(start_time_rx), rb_outputs, current_timestamp, None, None, on_transfer).await;
   }
 
   /// Start transmitting from owned ring buffers.
@@ -312,6 +332,7 @@ impl DeviceServer {
     start_time_rx: tokio::sync::oneshot::Receiver<Clock>,
     current_timestamp: Arc<AtomicUsize>,
     read_position: Arc<AtomicUsize>,
+    read_position_snapshot: Option<Arc<ReadPositionSnapshot>>,
     on_transfer: Option<TransferNotifier>,
   ) -> Vec<ring_buffer::RBInput<Sample, OwnedBuffer<Atomic<Sample>>>> {
     let mut rb_inputs = Vec::with_capacity(channel_count);
@@ -323,7 +344,7 @@ impl DeviceServer {
     }
     let rbs = rb_outputs.iter().map(|rbo| rbo.shared().clone()).collect_vec();
     *self.tx_peaks_supplier.write().unwrap() = Box::new(move || peaks_of_buffers(&rbs));
-    self.transmit(Some(start_time_rx), rb_outputs, current_timestamp, Some(read_position), on_transfer).await;
+    self.transmit(Some(start_time_rx), rb_outputs, current_timestamp, Some(read_position), read_position_snapshot, on_transfer).await;
     rb_inputs
   }
 
@@ -333,6 +354,7 @@ impl DeviceServer {
     rb_outputs: Vec<RBOutput<Sample, P>>,
     current_timestamp: Arc<AtomicUsize>,
     read_position: Option<Arc<AtomicUsize>>,
+    read_position_snapshot: Option<Arc<ReadPositionSnapshot>>,
     on_transfer: Option<TransferNotifier>,
   ) {
     let clock_rx = self.clock_receiver.subscribe();
@@ -346,6 +368,7 @@ impl DeviceServer {
       start_time_rx,
       current_timestamp.clone(),
       read_position.unwrap_or_else(|| Arc::new(AtomicUsize::new(usize::MAX))),
+      read_position_snapshot,
       on_transfer,
     );
     *self.flows_tx.lock().await = Some(flows_tx_handle);


### PR DESCRIPTION
This PR adds a small set of APIs to make Inferno easier to use as a transmit backend for externally scheduled, timestamped audio sources that are not driven by ALSA. These all came from developing my [Sendspin to Dante bridge](https://github.com/salanki/spin2dante). I tried to modify Inferno as little as possible, and approaches tried as alternatives to some of these APIs are described in the broader text below. Please note these implementations are heavily AI assisted.

The main additions are `transmit_from_owned_buffer()` for writer-controlled owned TX buffers and `ReadPositionSnapshot`, which publishes a consistent `(read_position, monotonic_time)` pair from the TX thread at the exact point TX advances its read cursor. The motivation came from integrating Inferno into a protocol bridge, but the underlying need is more general: external TX clients need both a safe owned-buffer write path and a precise observation primitive for “what TX is consuming now,” and trying to reconstruct that entirely outside Inferno turned out to be much less reliable.

## Summary (assisted by Codex)

This PR adds a small set of APIs that make Inferno easier to use as a transmit backend for external, timestamped audio sources that are not driven by ALSA.

It introduces:

1. `DeviceServer::transmit_from_owned_buffer()`
2. `ReadPositionSnapshot` for consistent `(read_position, monotonic_time)` observation from the TX thread
3. an explicit `ref_instant` contract so snapshot timestamps can be reconstructed correctly by external writers

These changes were developed while integrating Inferno into a protocol bridge that receives audio chunks with presentation timestamps and needs to place them accurately into Inferno’s TX ring buffers. The APIs are general enough to be useful for other non-ALSA / externally scheduled TX clients as well.

## Motivation

Inferno already exposes strong low-level TX primitives, but an external timestamped source needs two things that were awkward before this PR:

### 1. Owned TX buffers with writer-side control

For a timestamped source, the application needs to:
- hold audio in its own scheduling queue
- compute target write positions
- write directly into TX ring buffers
- rely on writer-visible `readable_pos` / hole-fix behavior

That is a better fit for Inferno-owned ring buffers than for externally wrapped buffers.

### 2. A precise observation point for “what the transmitter is consuming now”

The application also needs a trustworthy answer to:

> “At what local monotonic time did the TX thread advance to this exact read position?”

A plain `Arc<AtomicUsize>` for `read_position` was not enough by itself, because an external client has to pair it with its own `Instant::now()`. That leaves a timing gap between:
- when the TX thread updated `read_position`
- and when the client sampled local time

In our case, that observer gap was large enough to make accurate cross-device alignment difficult. The fix was to move the observation into the TX thread itself and publish a consistent pair.

## What this PR adds

### `transmit_from_owned_buffer()`

This is a convenience API for starting TX from newly created owned ring buffers and returning the corresponding `RBInput` write handles to the caller.

This is useful for applications that want Inferno to remain the owner of the TX buffer implementation, but need direct control over when and where samples are written.

Compared with external-buffer TX, this keeps the existing owned-buffer semantics:
- `readable_pos` tracking
- hole detection/fill support
- reads gated by what the writer has actually made readable

### `ReadPositionSnapshot`

This publishes a consistent `(read_position, monotonic_time)` snapshot from the TX thread at the exact point where TX updates `read_position`.

The implementation uses a simple single-writer seqlock pattern:
- odd `seq` while the writer is updating
- even `seq` when the snapshot is stable
- readers retry if the sequence changes mid-read

This avoids the race inherent in:
- reading `read_position`
- then calling `Instant::now()` elsewhere

### explicit `ref_instant`

The first version of the snapshot API exposed elapsed nanoseconds only. That turned out to leave an implicit contract between producer and consumer about the time origin.

This PR makes that contract explicit by storing a `ref_instant` in the snapshot itself and reconstructing the snapshot `Instant` from:
- `ref_instant`
- `monotonic_nanos`

That makes the API self-contained and much less error-prone for external consumers.

## Why this belongs in Inferno

I explored solving this entirely at the application layer first.

The application tried several approaches:
- one-shot timestamp anchors
- live retargeting from local time snapshots
- bounded correction / servo logic
- larger and smaller local buffers

Those approaches could improve parts of the behavior, but they all had to work around the same missing primitive: the application could not observe TX position and local monotonic time as one coherent event.

Once that observation moved into Inferno’s TX thread, the external scheduling logic became much simpler and much more stable.

So the main reason for this PR is not “support one specific project,” but:

- Inferno already knows the exact moment it advances TX read position
- that is the right place to publish this information
- external timestamped TX clients should not have to reconstruct it indirectly

## Backward compatibility

This PR is additive:
- existing TX paths continue to work
- existing callers of `transmit_from_external_buffer()` are unchanged
- the new snapshot is optional
- the existing `read_position: Arc<AtomicUsize>` path remains available

## Files changed

- `inferno_aoip/src/device_server/mod.rs`
- `inferno_aoip/src/device_server/flows_tx.rs`

## Commit structure

This PR intentionally keeps the changes as three small related commits:

1. `Add transmit_from_owned_buffer() for non-ALSA TX clients`
2. `Add ReadPositionSnapshot for precise TX timing observation`
3. `Expose ref_instant in ReadPositionSnapshot for correct time-base contract`

## Notes

If you prefer, I’m also happy to:
- rename `ReadPositionSnapshot`
- narrow the public API surface further
- or split the owned-buffer API and snapshot API into separate PRs

My view is that they fit well together because they serve the same class of external TX client.